### PR TITLE
Task: Use Symbols as private keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+### Fixed
+
+- [Use Symbols as keys to avoid collision.](https://github.com/leofavre/observed-properties/issues/11)
+
+
 ## [0.1.1] - 2018-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# observedProperties
+# Observed Properties
 
 Have you ever wondered why native web components have an API to handle attribute changes but not property changes?
 

--- a/index.js
+++ b/index.js
@@ -5,13 +5,15 @@ export const withObservedProperties = (Base = HTMLElement) =>
       const { observedProperties = [] } = this.constructor;
 
       observedProperties.forEach(propName => {
+        const privateKey = Symbol(propName);
+
         Object.defineProperty(this, propName, {
           get () {
-            return this[`_${propName}`];
+            return this[privateKey];
           },
           set (value) {
-            const oldValue = this[`_${propName}`];
-            this[`_${propName}`] = value;
+            const oldValue = this[privateKey];
+            this[privateKey] = value;
 
             if (typeof this.propertyChangedCallback === 'function') {
               this.propertyChangedCallback(propName, oldValue, value);

--- a/index.test.js
+++ b/index.test.js
@@ -64,10 +64,10 @@ describe('withObservedProperties', () => {
       .to.have.been.calledWith('rate', 125, 125);
   });
 
-  it('Should make getters for observed properties.', () => {
+  it('Should correctly access getters.', () => {
     testElement.propertyChangedCallback = undefined;
     testElement.rate = 85;
 
-    expect(testElement.rate).to.equal(testElement._rate);
+    expect(testElement.rate).to.equal(85);
   });
 });


### PR DESCRIPTION
Fixes issue #11 by using Symbols as private keys to avoid name collision.