### PR TITLE
Bugfix: Fix inherited values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- Fixed a bug that would cause the script to prioritize the inherited property value.
+- Fixed a bug that would cause the script to prioritize inherited property values over set ones.
 
 
 ## [0.1.4] - 2018-07-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+### Fixed
+
+- Fixed a bug that would cause the script to prioritize the inherited property value.
+
+
 ## [0.1.4] - 2018-07-13
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -4,18 +4,16 @@ export const withObservedProperties = (Base = HTMLElement) =>
       super();
       const { observedProperties = [] } = this.constructor;
       observedProperties.forEach(propName => {
-        const originalValue = this[propName];
+        const inheritedValue = this[propName];
         const privateKey = Symbol(propName);
+        this[privateKey] = inheritedValue;
 
         Object.defineProperty(this, propName, {
           get () {
             return this[privateKey];
           },
           set (value) {
-            const oldValue = (originalValue != null)
-              ? originalValue
-              : this[privateKey];
-
+            const oldValue = this[privateKey];
             this[privateKey] = value;
 
             if (typeof this.propertyChangedCallback === 'function') {

--- a/index.test.js
+++ b/index.test.js
@@ -92,6 +92,11 @@ describe('withObservedProperties', () => {
     testElement.rate = 80;
 
     expect(testElement.propertyChangedCallback)
-      .to.have.been.calledOnceWith('rate', 40, 80);
+      .to.have.been.calledWith('rate', 40, 80);
+
+    testElement.rate = 160;
+
+    expect(testElement.propertyChangedCallback)
+      .to.have.been.calledWith('rate', 80, 160);
   });
 });


### PR DESCRIPTION
Fixed a bug that would cause the script to prioritize inherited property values over set ones.